### PR TITLE
Feature/cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.egg-info
 build
 dist
+.cache

--- a/tests/urlmatch_test.py
+++ b/tests/urlmatch_test.py
@@ -7,45 +7,40 @@ sys.path.append('../')
 
 from urlmatch import urlmatch, BadMatchPattern
 
+
 class URLMatchTest(unittest.TestCase):
     """Tests that verify that the `urlmatch module functions correctly"""
 
     def setUp(self):
-        pass
+        self._root_url = 'http://test.com'
+
+    def _check_raises(self, pattern):
+        """
+        Check that a given pattern raises a BadMatchPattern exception.
+        """
+        with self.assertRaises(BadMatchPattern):
+            urlmatch(pattern, self._root_url)
 
     def test_invalid_scheme(self):
         """
         Tests that an invalid scheme raises a `BadMatchPattern` exception.
         """
-
-        with self.assertRaises(BadMatchPattern):
-            urlmatch('bad://test.com/*', 'http://test.com')
-
-        with self.assertRaises(BadMatchPattern):
-            urlmatch('http:/test.com/*', 'http://test.com')
+        self._check_raises('bad://test.com/*')
+        self._check_raises('http:/test.com/*')
 
     def test_invalid_domain(self):
         """
         Tests that an invalid domain raises a `BadMatchPattern` exception.
         """
-
-        with self.assertRaises(BadMatchPattern):
-            urlmatch('http:///*', 'http://test.com')
-
-        with self.assertRaises(BadMatchPattern):
-            urlmatch('http://*test/*', 'http://test.com')
-
-        with self.assertRaises(BadMatchPattern):
-            urlmatch('http://sub.*.test/*', 'http://test.com')
+        self._check_raises('http:///*')
+        self._check_raises('http://*test/*')
+        self._check_raises('http://sub.*.test/*')
 
     def test_invalid_path(self):
         """
         Tests that an invalid path raises a `BadMatchPattern` exception.
         """
-        pattern = 'http://test.com'
-
-        with self.assertRaises(BadMatchPattern):
-            urlmatch(pattern, 'http://test.com')
+        self._check_raises('http://test.com')
 
     def test_match_all(self):
         """
@@ -277,10 +272,3 @@ class URLMatchTest(unittest.TestCase):
         self.assertIsNone(urlmatch(pattern, 'http://@test.com/'))
         self.assertIsNone(urlmatch(pattern, 'http://user.test:@test.com/'))
         self.assertIsNone(urlmatch(pattern, 'http://user.test:password@test.com/'))
-
-
-
-
-
-
-

--- a/urlmatch/urlmatch.py
+++ b/urlmatch/urlmatch.py
@@ -3,26 +3,27 @@ urlmatch lets you easily check whether urls are on a domain or subdomain
 """
 import re
 
+
 class BadMatchPattern(Exception):
     """The Exception that's raised when a match pattern fails"""
     pass
 
-def parse_match_pattern(pattern, path_required=True, fuzzy_scheme=False, http_auth_allowed=True):
+
+def parse_match_pattern(pattern, path_required=True, fuzzy_scheme=False,
+                        http_auth_allowed=True):
     """
     Returns the regular expression for a given match pattern.
 
     Args:
-
         pattern: a `urlmatch` formatted match pattern
         path_required: a `bool` which dicates whether the match pattern
             must have path
         fuzzy_scheme: if this is true, then if the scheme is `*`, `http`,
             or `https`, it will match both `http` and `https`
-        http_auth_allowed: if this is true, then URLs with http auth on the correct
-            domain and path will be matched
+        http_auth_allowed: if this is true, then URLs with http auth on the
+            correct domain and path will be matched
 
     Returns:
-
         a regular expresion for the match pattern
     """
     if not isinstance(pattern, basestring):
@@ -42,7 +43,8 @@ def parse_match_pattern(pattern, path_required=True, fuzzy_scheme=False, http_au
     if http_auth_allowed:
         # add optional HTTP auth
         safe_characters = "[^\/:.]"
-        pattern_regex += "(?:{safe}+(?:\:{safe}+)?@)?".format(safe=safe_characters)
+        pattern_regex += "(?:{safe}+(?:\:{safe}+)?@)?".format(
+            safe=safe_characters)
 
     pattern = pattern[len(result.group(0)):]
 
@@ -81,8 +83,7 @@ def urlmatch(match_pattern, url, **kwargs):
     if isinstance(match_pattern, basestring):
         match_pattern = map(str.strip, match_pattern.split(','))
 
-    regex = "({})".format("|".join(map(lambda x: parse_match_pattern(x, **kwargs), match_pattern)))
+    regex = "({})".format("|".join(map(
+        lambda x: parse_match_pattern(x, **kwargs), match_pattern)))
 
     return regex and re.search(regex, url)
-
-


### PR DESCRIPTION
Make the code PEP 8 compliant.

Refactor the unit tests to avoid code duplication. This makes the tests slightly harder to use as a usage reference, but it has removed 80 lines of code and a load of hard coded strings.
