### PR TITLE
Make urlmatch return an explicit boolean

### DIFF
--- a/urlmatch/urlmatch.py
+++ b/urlmatch/urlmatch.py
@@ -86,4 +86,4 @@ def urlmatch(match_pattern, url, **kwargs):
     regex = "({})".format("|".join(map(
         lambda x: parse_match_pattern(x, **kwargs), match_pattern)))
 
-    return regex and re.search(regex, url)
+    return bool(regex and re.search(regex, url))


### PR DESCRIPTION
The urlmatch function now returns True or False.

Before it returned a _sre.SRE_Match object or None. Whilst these evaluate to True and False they are not particularly intuitive.

This breaks the signature of the method so will require a major version change when next publishing to PyPI.
