### PR TITLE
Python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python:
+  - "2.7"
+  - "3.2"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+# command to run tests
+script: python setup.py test

--- a/tests/urlmatch_test.py
+++ b/tests/urlmatch_test.py
@@ -1,9 +1,6 @@
 """Tests that verify that the `urlmatch` module functions correctly"""
 
 import unittest
-import sys
-
-sys.path.append('../')
 
 from urlmatch import urlmatch, BadMatchPattern
 

--- a/urlmatch/__init__.py
+++ b/urlmatch/__init__.py
@@ -1,1 +1,1 @@
-from urlmatch import urlmatch
+from .urlmatch import urlmatch, BadMatchPattern

--- a/urlmatch/urlmatch.py
+++ b/urlmatch/urlmatch.py
@@ -26,9 +26,6 @@ def parse_match_pattern(pattern, path_required=True, fuzzy_scheme=False,
     Returns:
         a regular expresion for the match pattern
     """
-    if not isinstance(pattern, basestring):
-        return
-
     pattern_regex = "(?:^"
     result = re.search(r'^(\*|https?):\/\/', pattern)
     if not result:
@@ -80,7 +77,7 @@ def urlmatch(match_pattern, url, **kwargs):
         match_pattern: a `urlmatch` formatted match pattern_regex
         url: a url
     """
-    if isinstance(match_pattern, basestring):
+    if isinstance(match_pattern, str):
         match_pattern = map(str.strip, match_pattern.split(','))
 
     regex = "({})".format("|".join(map(

--- a/urlmatch/urlmatch.py
+++ b/urlmatch/urlmatch.py
@@ -42,8 +42,8 @@ def parse_match_pattern(pattern, path_required=True, fuzzy_scheme=False,
 
     if http_auth_allowed:
         # add optional HTTP auth
-        safe_characters = "[^\/:.]"
-        pattern_regex += "(?:{safe}+(?:\:{safe}+)?@)?".format(
+        safe_characters = r"[^\/:.]"
+        pattern_regex += r"(?:{safe}+(?:\:{safe}+)?@)?".format(
             safe=safe_characters)
 
     pattern = pattern[len(result.group(0)):]


### PR DESCRIPTION
Support for Python 3.

The only real change is `basestring` => `str`. This is fine because we did not support python 2 `unicode` objects in the first place. Calling urlmatch with a unicode object resulted in: `TypeError: descriptor 'strip' requires a 'str' object but received a 'unicode'`

Take or leave the `.travis.yml` file - you would have to create and configure an account (5 minute task).